### PR TITLE
LFLT-499 Improve LSAS WebClient configuration to avoid using socat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,10 @@ RUN adduser --system --no-create-home --gid 1000 --uid 1000 $APP_USER
 RUN mkdir -p $APP_HOME
 ADD web/target/$APP_EXECUTABLE $APP_HOME
 ADD config/leaflet-sas-exec.conf $APP_HOME
-ADD config/start.sh $APP_HOME
-
-RUN apt-get update && apt-get install -y socat
 
 WORKDIR $APP_HOME
 RUN chmod 744 $APP_HOME
 RUN chmod 744 $APP_EXECUTABLE
 RUN chown -R $APP_USER:$APP_USER $APP_HOME
-RUN chmod u+x start.sh
 
-ENTRYPOINT ./start.sh
+ENTRYPOINT ./$ENV_APP_EXECUTABLE ${APP_ARGS}

--- a/config/start.sh
+++ b/config/start.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-socat TCP-LISTEN:2375,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock &
-su $ENV_APP_USER -s /bin/sh -c "./$ENV_APP_EXECUTABLE ${APP_ARGS}"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lsas</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.4.0-dev</version>
+        <version>2.5.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -59,6 +59,11 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactory.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactory.java
@@ -1,0 +1,69 @@
+package hu.psprog.leaflet.lsas.core.client.factory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
+import io.netty.channel.unix.DomainSocketAddress;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.ClientCodecConfigurer;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+/**
+ * Factory implementation for creating a {@link WebClient} instance used for Docker Engine API communication.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class DockerEngineWebClientFactory {
+
+    private final ServiceRegistrations.DockerIntegration dockerIntegration;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public DockerEngineWebClientFactory(ServiceRegistrations serviceRegistrations, ObjectMapper objectMapper) {
+        this.dockerIntegration = serviceRegistrations.getDockerIntegration();
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Creates a {@link WebClient} instance based on the currently set Docker integration mode.
+     * In case the integration mode ({@code lsas.docker-integration.integration-mode} parameter) is set to TCP,
+     * the WebClient will expect a TCP endpoint. Otherwise, (in case of SOCKET integration mode) the host address
+     * should be a socket path and WebClient will use a {@link ReactorClientHttpConnector} adapter to establish connection.
+     *
+     * @return instantiated {@link WebClient}
+     */
+    public WebClient createWebClient() {
+
+        WebClient.Builder webClientBuilder = WebClient.builder()
+                .codecs(clientCodecConfigurer -> registerJacksonDecoderCodec(objectMapper, clientCodecConfigurer));
+
+        if (isDockerSocketIntegrationSelected()) {
+            webClientBuilder.clientConnector(createReactorClientHttpConnector());
+        } else {
+            webClientBuilder.baseUrl(dockerIntegration.getEngineHost());
+        }
+
+        return webClientBuilder.build();
+    }
+
+    private void registerJacksonDecoderCodec(ObjectMapper objectMapper, ClientCodecConfigurer clientCodecConfigurer) {
+        clientCodecConfigurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.ALL));
+    }
+
+    private boolean isDockerSocketIntegrationSelected() {
+        return dockerIntegration.getIntegrationMode() == ServiceRegistrations.DockerIntegration.IntegrationMode.SOCKET;
+    }
+
+    private ReactorClientHttpConnector createReactorClientHttpConnector() {
+
+        HttpClient dockerHttpClient = HttpClient.create()
+                .remoteAddress(() -> new DomainSocketAddress(dockerIntegration.getEngineHost()));
+
+        return new ReactorClientHttpConnector(dockerHttpClient);
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerContainerStatisticsClientImpl.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerContainerStatisticsClientImpl.java
@@ -5,6 +5,7 @@ import hu.psprog.leaflet.lsas.core.dockerapi.ContainerDetailsModel;
 import hu.psprog.leaflet.lsas.core.dockerapi.ContainerModel;
 import hu.psprog.leaflet.lsas.core.dockerapi.ContainerRuntimeStatsModel;
 import hu.psprog.leaflet.lsas.core.domain.DockerPath;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,7 @@ import java.util.List;
  * @author Peter Smith
  */
 @Component
+@Slf4j
 public class DockerContainerStatisticsClientImpl implements DockerContainerStatisticsClient {
 
     private static final ParameterizedTypeReference<List<ContainerModel>> CONTAINER_MODEL_LIST_TYPEREF
@@ -50,7 +52,10 @@ public class DockerContainerStatisticsClientImpl implements DockerContainerStati
                 .uri(DockerPath.CONTAINER_DETAILS.getURI(), containerID)
                 .retrieve()
                 .bodyToMono(ContainerDetailsModel.class)
-                .onErrorResume(throwable -> Mono.empty());
+                .onErrorResume(throwable -> {
+                    log.error(String.format("Failed to retrieve details for container=[%s]", containerID), throwable);
+                    return Mono.empty();
+                });
     }
 
     @Override
@@ -61,6 +66,9 @@ public class DockerContainerStatisticsClientImpl implements DockerContainerStati
                 .uri(DockerPath.CONTAINER_STATS.getURI(), containerID)
                 .retrieve()
                 .bodyToFlux(ContainerRuntimeStatsModel.class)
-                .onErrorResume(throwable -> Flux.empty());
+                .onErrorResume(throwable -> {
+                    log.error(String.format("Failed to retrieve statistics for container=[%s]", containerID), throwable);
+                    return Flux.empty();
+                });
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/config/ServiceRegistrations.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/config/ServiceRegistrations.java
@@ -69,8 +69,17 @@ public class ServiceRegistrations {
      */
     public static class DockerIntegration {
 
+        private IntegrationMode integrationMode = IntegrationMode.TCP;
         private String engineHost;
         private final Map<String, DockerRegistry> registryCatalog = new HashMap<>();
+
+        public IntegrationMode getIntegrationMode() {
+            return integrationMode;
+        }
+
+        public void setIntegrationMode(IntegrationMode integrationMode) {
+            this.integrationMode = integrationMode;
+        }
 
         public String getEngineHost() {
             return engineHost;
@@ -93,6 +102,7 @@ public class ServiceRegistrations {
             DockerIntegration that = (DockerIntegration) o;
 
             return new EqualsBuilder()
+                    .append(integrationMode, that.integrationMode)
                     .append(engineHost, that.engineHost)
                     .append(registryCatalog, that.registryCatalog)
                     .isEquals();
@@ -101,6 +111,7 @@ public class ServiceRegistrations {
         @Override
         public int hashCode() {
             return new HashCodeBuilder(17, 37)
+                    .append(integrationMode)
                     .append(engineHost)
                     .append(registryCatalog)
                     .toHashCode();
@@ -109,9 +120,15 @@ public class ServiceRegistrations {
         @Override
         public String toString() {
             return new ToStringBuilder(this)
+                    .append("integrationMode", integrationMode)
                     .append("engineHost", engineHost)
                     .append("registryCatalog", registryCatalog)
                     .toString();
+        }
+
+        public enum IntegrationMode {
+            SOCKET,
+            TCP
         }
     }
 

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactoryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactoryTest.java
@@ -1,0 +1,164 @@
+package hu.psprog.leaflet.lsas.core.client.factory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
+import io.netty.channel.unix.DomainSocketAddress;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.ClientCodecConfigurer;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientConfig;
+
+import java.lang.reflect.Field;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link DockerEngineWebClientFactory}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class DockerEngineWebClientFactoryTest {
+
+    private static final String TCP_ADDRESS = "http://localhost:9999";
+    private static final String SOCKET_PATH = "/path/to/socket";
+
+    @Mock
+    private ServiceRegistrations serviceRegistrations;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private ClientCodecConfigurer clientCodecConfigurer;
+
+    @Mock
+    private ClientCodecConfigurer.ClientDefaultCodecs clientDefaultCodecs;
+
+    @Captor
+    private ArgumentCaptor<ClientHttpConnector> connectorCaptor;
+
+    @Captor
+    private ArgumentCaptor<Consumer<ClientCodecConfigurer>> codecCaptor;
+
+    private DockerEngineWebClientFactory dockerEngineWebClientFactory;
+
+    @Test
+    public void shouldFactoryCreateTCPClient() {
+
+        try (MockedStatic<WebClient> mockedWebClient = mockStatic(WebClient.class)) {
+
+            // given
+            prepareFactory(ServiceRegistrations.DockerIntegration.IntegrationMode.TCP);
+            mockedWebClient.when(WebClient::builder).thenReturn(webClientBuilder);
+            given(webClientBuilder.codecs(any())).willReturn(webClientBuilder);
+            given(webClientBuilder.build()).willReturn(webClient);
+
+            // when
+            WebClient result = dockerEngineWebClientFactory.createWebClient();
+
+            // then
+            assertThat(result, equalTo(webClient));
+            verify(webClientBuilder).baseUrl(TCP_ADDRESS);
+            verifyCodecConfigurerRegistration();
+        }
+    }
+
+    @Test
+    public void shouldFactoryCreateSocketClient() throws IllegalAccessException, ClassNotFoundException {
+
+        try (MockedStatic<WebClient> mockedWebClient = mockStatic(WebClient.class)) {
+
+            // given
+            prepareFactory(ServiceRegistrations.DockerIntegration.IntegrationMode.SOCKET);
+            mockedWebClient.when(WebClient::builder).thenReturn(webClientBuilder);
+            given(webClientBuilder.codecs(any())).willReturn(webClientBuilder);
+            given(webClientBuilder.build()).willReturn(webClient);
+
+            // when
+            WebClient result = dockerEngineWebClientFactory.createWebClient();
+
+            // then
+            assertThat(result, equalTo(webClient));
+            verify(webClientBuilder).clientConnector(connectorCaptor.capture());
+            verifyCodecConfigurerRegistration();
+
+            ClientHttpConnector connectorCaptorValue = connectorCaptor.getValue();
+            assertThat(connectorCaptorValue instanceof ReactorClientHttpConnector, is(true));
+
+            HttpClient httpClient = extractClient(connectorCaptorValue);
+            assertThat(httpClient, notNullValue());
+
+            HttpClientConfig httpClientConfig = extractClientConfig(httpClient);
+            assertThat(httpClientConfig, notNullValue());
+
+            assertThat(httpClientConfig.remoteAddress().get() instanceof DomainSocketAddress, is(true));
+            assertThat(httpClientConfig.remoteAddress().get().toString(), equalTo(SOCKET_PATH));
+        }
+    }
+
+    private void verifyCodecConfigurerRegistration() {
+
+        given(clientCodecConfigurer.defaultCodecs()).willReturn(clientDefaultCodecs);
+
+        verify(webClientBuilder).codecs(codecCaptor.capture());
+
+        Consumer<ClientCodecConfigurer> configurerValue = codecCaptor.getValue();
+        configurerValue.accept(clientCodecConfigurer);
+        verify(clientDefaultCodecs).jackson2JsonDecoder(any(Jackson2JsonDecoder.class));
+    }
+
+    private HttpClient extractClient(ClientHttpConnector clientHttpConnector) throws IllegalAccessException {
+
+        Field httpClientField = ReflectionUtils.findField(ReactorClientHttpConnector.class, "httpClient");
+        httpClientField.setAccessible(true);
+
+        return (HttpClient) httpClientField.get(clientHttpConnector);
+    }
+
+    private HttpClientConfig extractClientConfig(HttpClient httpClient) throws ClassNotFoundException, IllegalAccessException {
+
+        Field httpClientConfig = ReflectionUtils.findField(Class.forName("reactor.netty.http.client.HttpClientConnect"), "config");
+        httpClientConfig.setAccessible(true);
+
+        return (HttpClientConfig) httpClientConfig.get(httpClient);
+    }
+
+    private void prepareFactory(ServiceRegistrations.DockerIntegration.IntegrationMode integrationMode) {
+
+        ServiceRegistrations.DockerIntegration dockerIntegration = new ServiceRegistrations.DockerIntegration();
+        dockerIntegration.setIntegrationMode(integrationMode);
+        dockerIntegration.setEngineHost(integrationMode == ServiceRegistrations.DockerIntegration.IntegrationMode.TCP
+                ? TCP_ADDRESS
+                : SOCKET_PATH);
+
+        given(serviceRegistrations.getDockerIntegration()).willReturn(dockerIntegration);
+
+        dockerEngineWebClientFactory = new DockerEngineWebClientFactory(serviceRegistrations, objectMapper);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>lsas</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.0-dev</version>
+    <version>2.5.0-dev</version>
 
     <modules>
         <module>web</module>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lsas</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.4.0-dev</version>
+        <version>2.5.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Implemented support for WebClient to be able to directly connect to Docker Engine API socket
 - Removed start.sh script
 - Removed socat installation step from Dockerfile
 - Added new unit tests
 - Bumped service version to 2.5.0-dev