### PR TITLE
LFLT-499 Improve LSAS WebClient configuration to avoid using socat

### DIFF
--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/MemoryStatsModel.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/MemoryStatsModel.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Model class representing a Docker container's memory usage statistics information.
@@ -53,7 +54,12 @@ public class MemoryStatsModel {
 
         @JsonProperty("stats")
         public MemoryStatsModelBuilder stats(Map<String, Object> stats) {
-            this.cache = Long.valueOf(String.valueOf(stats.get("cache")));
+
+            this.cache = Optional.ofNullable(stats.get("cache"))
+                    .map(String::valueOf)
+                    .map(Long::valueOf)
+                    .orElse(0L);
+
             return this;
         }
 

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/utility/MemoryUsageCalculatorTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/utility/MemoryUsageCalculatorTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -62,6 +63,7 @@ class MemoryUsageCalculatorTest {
 
         return Stream.of(
                 Arguments.arguments(memoryStatsModel(104857600L, 0L, 0L), 100),
+                Arguments.arguments(memoryStatsModel(104857600L, null, 0L), 100),
                 Arguments.arguments(memoryStatsModel(104857000L, 0L, 0L), 99),
                 Arguments.arguments(memoryStatsModel(104857600L, 10485760L, 0L), 90),
                 Arguments.arguments(null, 0)
@@ -72,6 +74,7 @@ class MemoryUsageCalculatorTest {
 
         return Stream.of(
                 Arguments.arguments(memoryStatsModel(104857600L, 0L, 3221225472L), 3.26),
+                Arguments.arguments(memoryStatsModel(104857600L, null, 3221225472L), 3.26),
                 Arguments.arguments(memoryStatsModel(104857600L, 10485760L, 188743680L), 50.0),
                 Arguments.arguments(memoryStatsModel(104857600L, 0L, 0L), 0.0),
                 Arguments.arguments(null, 0.0)
@@ -80,9 +83,12 @@ class MemoryUsageCalculatorTest {
 
     private static MemoryStatsModel memoryStatsModel(Long usage, Long cache, Long limit) {
 
+        Map<String, Object> statsMap = new HashMap<>();
+        statsMap.put("cache", cache);
+
         return MemoryStatsModel.builder()
                 .usage(usage)
-                .stats(Map.of("cache", cache))
+                .stats(statsMap)
                 .limit(limit)
                 .build();
     }


### PR DESCRIPTION
 - Fixed NumberFormatException in MemoryStatsModel when "cache" memory is not provided
 - Aligned relevant unit test cases