### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   jira: circleci/jira@2.2.0
-  gh: circleci/github-cli@2.7.0
+  gh: circleci/github-cli@2.7.2
 
 # Common parameters for CircleCI build config
 parameters:
@@ -24,6 +24,9 @@ parameters:
   version_file:
     type: string
     default: "version"
+  deploy_name:
+    type: string
+    default: "prod-deploy-lsas"
 
 # Reusable commands
 commands:
@@ -93,6 +96,15 @@ jobs:
             fi
           name: Push Docker image
       - run:
+          name: Plan deployment
+          command: |
+            if [[ $CIRCLE_BRANCH == "deploy" ]]; then
+              circleci run release plan << pipeline.parameters.deploy_name >> \
+                --environment-name=production \
+                --component-name=<< pipeline.parameters.app_name >> \
+                --target-version="${PROJECT_VERSION}"
+            fi
+      - run:
           command: |
             mkdir -p << pipeline.parameters.workspace_dir >>
             cp ./<< pipeline.parameters.executable_source_dir >><< pipeline.parameters.executable_file >> << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
@@ -126,11 +138,18 @@ jobs:
       - run:
           command: |
             set -e
-
-            export DOMINO_CLI_PREAUTHORIZED_TOKEN="$(domino-cli --cicd auth --generate-token)"
+            
+            circleci run release update << pipeline.parameters.deploy_name >> --status=running
+            
+            echo "Requesting access token ..."
+            token="$(domino-cli --cicd auth --generate-token)" || exit 1
+            export DOMINO_CLI_PREAUTHORIZED_TOKEN=$token
             
             domino-cli --cicd import
             echo "Deployment definition successfully imported"
+            
+            domino-cli --cicd oauth-import << pipeline.parameters.app_name >>
+            echo "Deployment OAuth descriptor successfully imported"
             
             domino-cli --cicd deploy << pipeline.parameters.app_name >> ${PROJECT_VERSION}
             echo "Successfully deployed application << pipeline.parameters.app_name >> v${PROJECT_VERSION}"
@@ -139,6 +158,24 @@ jobs:
             echo "Successfully started application << pipeline.parameters.app_name >>"
 
           name: Deploy via Domino
+      - run:
+          name: Update planned release to SUCCESS
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=SUCCESS
+          when: on_success
+      - run:
+          name: Update planned release to FAILED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=FAILED
+          when: on_fail
+
+  cancel-deploy:
+    executor: base
+    steps:
+      - run:
+          name: Update planned release to CANCELED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=CANCELED
 
   # Leaflet Stack Admin Service - Publish tag (and release) on GitHub for RC versions
   publish-github-rc:
@@ -214,6 +251,11 @@ workflows:
                 job_type: deployment
                 pipeline_id: << pipeline.id >>
                 pipeline_number: << pipeline.number >>
+
+      - cancel-deploy:
+          requires:
+            - deploy:
+                - canceled
 
       - publish-github-release:
           context:

--- a/.domino/oauth.yml
+++ b/.domino/oauth.yml
@@ -1,0 +1,26 @@
+domino:
+  oauth:
+    lsas:
+      behavior:
+        target-provider: gateway-psproghu
+        roll-client-secret-on-deploy: true
+        use-secret-manager-for:
+          - client-secret
+          - client-id
+      tenant:
+        environment: prod
+        name: psproghu
+      resource-server:
+        use-audience: true
+        registered-permissions:
+          - read:docker:containers
+          - read:docker:registry
+          - read:services:status
+          - write:docker:registry
+        allowed-clients:
+          - name: lpmc
+            allowed-permissions:
+              - read:docker:containers
+              - read:docker:registry
+              - read:services:status
+              - write:docker:registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,16 @@ ARG APP_HOME=/opt/lsas
 ARG APP_EXECUTABLE=leaflet-sas-exec.jar
 ENV ENV_APP_EXECUTABLE=$APP_EXECUTABLE
 ENV ENV_APP_USER=$APP_USER
+ENV JAVA_OPTS="-Xmx128M"
 
 RUN addgroup --system --gid 1000 $APP_USER
 RUN adduser --system --no-create-home --gid 1000 --uid 1000 $APP_USER
 RUN mkdir -p $APP_HOME
 ADD web/target/$APP_EXECUTABLE $APP_HOME
-ADD config/leaflet-sas-exec.conf $APP_HOME
 
 WORKDIR $APP_HOME
 RUN chmod 744 $APP_HOME
 RUN chmod 744 $APP_EXECUTABLE
 RUN chown -R $APP_USER:$APP_USER $APP_HOME
 
-ENTRYPOINT ./$ENV_APP_EXECUTABLE ${APP_ARGS}
+ENTRYPOINT exec java $JAVA_OPTS -jar $ENV_APP_EXECUTABLE ${APP_ARGS}

--- a/config/leaflet-sas-exec.conf
+++ b/config/leaflet-sas-exec.conf
@@ -1,1 +1,0 @@
-JAVA_OPTS=-Xmx128M

--- a/core/lombok.config
+++ b/core/lombok.config
@@ -1,0 +1,1 @@
+lombok.jacksonized.jacksonVersion += 3

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lsas</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.8.1-dev</version>
+        <version>2.9.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,36 +21,12 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
-            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
+            <groupId>hu.psprog.leaflet</groupId>
+            <artifactId>bridge-implementation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-math3</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactory.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactory.java
@@ -1,16 +1,16 @@
 package hu.psprog.leaflet.lsas.core.client.factory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
 import io.netty.channel.unix.DomainSocketAddress;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.ClientCodecConfigurer;
-import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.JacksonJsonDecoder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Factory implementation for creating a {@link WebClient} instance used for Docker Engine API communication.
@@ -21,12 +21,12 @@ import reactor.netty.http.client.HttpClient;
 public class DockerEngineWebClientFactory {
 
     private final ServiceRegistrations.DockerIntegration dockerIntegration;
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
 
     @Autowired
-    public DockerEngineWebClientFactory(ServiceRegistrations serviceRegistrations, ObjectMapper objectMapper) {
+    public DockerEngineWebClientFactory(ServiceRegistrations serviceRegistrations, JsonMapper jsonMapper) {
         this.dockerIntegration = serviceRegistrations.getDockerIntegration();
-        this.objectMapper = objectMapper;
+        this.jsonMapper = jsonMapper;
     }
 
     /**
@@ -40,7 +40,7 @@ public class DockerEngineWebClientFactory {
     public WebClient createWebClient() {
 
         WebClient.Builder webClientBuilder = WebClient.builder()
-                .codecs(clientCodecConfigurer -> registerJacksonDecoderCodec(objectMapper, clientCodecConfigurer));
+                .codecs(this::registerJacksonDecoderCodec);
 
         if (isDockerSocketIntegrationSelected()) {
             webClientBuilder.clientConnector(createReactorClientHttpConnector());
@@ -51,8 +51,8 @@ public class DockerEngineWebClientFactory {
         return webClientBuilder.build();
     }
 
-    private void registerJacksonDecoderCodec(ObjectMapper objectMapper, ClientCodecConfigurer clientCodecConfigurer) {
-        clientCodecConfigurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.ALL));
+    private void registerJacksonDecoderCodec(ClientCodecConfigurer clientCodecConfigurer) {
+        clientCodecConfigurer.defaultCodecs().jacksonJsonDecoder(new JacksonJsonDecoder(jsonMapper, MediaType.ALL));
     }
 
     private boolean isDockerSocketIntegrationSelected() {

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerContainerStatisticsClientImpl.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerContainerStatisticsClientImpl.java
@@ -53,7 +53,7 @@ public class DockerContainerStatisticsClientImpl implements DockerContainerStati
                 .retrieve()
                 .bodyToMono(ContainerDetailsModel.class)
                 .onErrorResume(throwable -> {
-                    log.error(String.format("Failed to retrieve details for container=[%s]", containerID), throwable);
+                    log.error("Failed to retrieve details for container=[{}]", containerID, throwable);
                     return Mono.empty();
                 });
     }
@@ -67,7 +67,7 @@ public class DockerContainerStatisticsClientImpl implements DockerContainerStati
                 .retrieve()
                 .bodyToFlux(ContainerRuntimeStatsModel.class)
                 .onErrorResume(throwable -> {
-                    log.error(String.format("Failed to retrieve statistics for container=[%s]", containerID), throwable);
+                    log.error("Failed to retrieve statistics for container=[{}]", containerID, throwable);
                     return Flux.empty();
                 });
     }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImpl.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImpl.java
@@ -8,7 +8,7 @@ import hu.psprog.leaflet.lsas.core.dockerapi.DockerTags;
 import hu.psprog.leaflet.lsas.core.domain.DockerRegistryPath;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.JacksonJsonDecoder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -30,7 +30,7 @@ public class DockerRegistryClientImpl implements DockerRegistryClient {
     private final Map<String, WebClient> clientMap;
 
     @Autowired
-    public DockerRegistryClientImpl(ServiceRegistrations serviceRegistrations, Jackson2JsonDecoder dockerManifestDecoder) {
+    public DockerRegistryClientImpl(ServiceRegistrations serviceRegistrations, JacksonJsonDecoder dockerManifestDecoder) {
         this.clientMap = prepareClientMap(serviceRegistrations, dockerManifestDecoder);
     }
 
@@ -99,7 +99,7 @@ public class DockerRegistryClientImpl implements DockerRegistryClient {
         return selectedWebClient;
     }
 
-    private Map<String, WebClient> prepareClientMap(ServiceRegistrations serviceRegistrations, Jackson2JsonDecoder dockerManifestDecoder) {
+    private Map<String, WebClient> prepareClientMap(ServiceRegistrations serviceRegistrations, JacksonJsonDecoder dockerManifestDecoder) {
 
         return serviceRegistrations.getDockerIntegration()
                 .getRegistryCatalog()
@@ -107,7 +107,7 @@ public class DockerRegistryClientImpl implements DockerRegistryClient {
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> buildWebClient(entry.getValue(), dockerManifestDecoder)));
     }
 
-    private WebClient buildWebClient(ServiceRegistrations.DockerRegistry dockerRegistry, Jackson2JsonDecoder dockerManifestDecoder) {
+    private WebClient buildWebClient(ServiceRegistrations.DockerRegistry dockerRegistry, JacksonJsonDecoder dockerManifestDecoder) {
 
         String basicAuth = String.format("%s:%s", dockerRegistry.getUsername(), dockerRegistry.getPassword());
         String authHeader = String.format("Basic %s", Base64.getEncoder().encodeToString(basicAuth.getBytes()));

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/config/ServiceConfiguration.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/config/ServiceConfiguration.java
@@ -1,16 +1,20 @@
 package hu.psprog.leaflet.lsas.core.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import hu.psprog.leaflet.bridge.client.handler.ResponseReader;
+import hu.psprog.leaflet.bridge.client.impl.ResponseReaderImpl;
+import hu.psprog.leaflet.bridge.client.request.RequestAdapter;
 import hu.psprog.leaflet.lsas.core.client.factory.DockerEngineWebClientFactory;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.util.TimeValue;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.JacksonJsonDecoder;
 import org.springframework.util.MimeType;
 import org.springframework.web.reactive.function.client.WebClient;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.concurrent.TimeUnit;
 
@@ -22,13 +26,28 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 public class ServiceConfiguration {
 
-    @Bean
-    public Client jerseyClient(ObjectMapper objectMapper, @Value("${lsas.call-timeout}") int readTimeout) {
+    private static final TimeValue MAX_IDLE_TIME = TimeValue.ofSeconds(30L);
+    private static final RequestAdapter DUMMY_REQUEST_ADAPTER = new DummyRequestAdapter();
 
-        return ClientBuilder.newBuilder()
-                .register(new JacksonJsonProvider(objectMapper))
-                .readTimeout(readTimeout, TimeUnit.MILLISECONDS)
+    @Bean
+    public HttpClient bridgeHttpClient(@Value("${lsas.call-timeout}") int readTimeout) {
+
+        return HttpClientBuilder.create()
+                .disableAuthCaching()
+                .disableAutomaticRetries()
+                .disableConnectionState()
+                .disableCookieManagement()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(RequestConfig.copy(RequestConfig.DEFAULT)
+                        .setResponseTimeout(readTimeout, TimeUnit.MILLISECONDS)
+                        .build())
+                .evictIdleConnections(MAX_IDLE_TIME)
                 .build();
+    }
+
+    @Bean
+    public ResponseReader responseReader(JsonMapper jsonMapper) {
+        return new ResponseReaderImpl(DUMMY_REQUEST_ADAPTER, jsonMapper);
     }
 
     @Bean
@@ -37,7 +56,24 @@ public class ServiceConfiguration {
     }
 
     @Bean
-    public Jackson2JsonDecoder dockerManifestDecoder(ObjectMapper objectMapper) {
-        return new Jackson2JsonDecoder(objectMapper, new MimeType("application", "vnd.docker.distribution.manifest.v1+prettyjws"));
+    public JacksonJsonDecoder dockerManifestDecoder(JsonMapper jsonMapper) {
+        return new JacksonJsonDecoder(jsonMapper, new MimeType("application", "vnd.docker.distribution.manifest.v1+prettyjws"));
+    }
+
+    static class DummyRequestAdapter implements RequestAdapter {
+
+        @Override
+        public String provideDeviceID() {
+            return "";
+        }
+
+        @Override
+        public String provideClientID() {
+            return "";
+        }
+
+        @Override
+        public void consumeAuthenticationToken(String token) {
+        }
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/ContainerDetailsModel.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/ContainerDetailsModel.java
@@ -1,7 +1,7 @@
 package hu.psprog.leaflet.lsas.core.dockerapi;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import java.time.ZonedDateTime;
 import java.util.Map;

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/MemoryStatsModel.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/MemoryStatsModel.java
@@ -1,9 +1,8 @@
 package hu.psprog.leaflet.lsas.core.dockerapi;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.apache.commons.lang3.StringUtils;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.Map;
 import java.util.Optional;
@@ -24,7 +23,7 @@ public record MemoryStatsModel(
         return new MemoryStatsModelBuilder();
     }
 
-    @JsonPOJOBuilder(withPrefix = StringUtils.EMPTY)
+    @JsonPOJOBuilder(withPrefix = "")
     public static final class MemoryStatsModelBuilder {
 
         private Long usage = 0L;

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/service/factory/impl/ActuatorBasedServiceStatusAdapterFactoryImpl.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/service/factory/impl/ActuatorBasedServiceStatusAdapterFactoryImpl.java
@@ -1,13 +1,14 @@
 package hu.psprog.leaflet.lsas.core.service.factory.impl;
 
+import hu.psprog.leaflet.bridge.client.handler.ResponseReader;
 import hu.psprog.leaflet.lsas.core.service.factory.ServiceStatusAdapterFactory;
 import hu.psprog.leaflet.lsas.core.status.impl.ActuatorBasedServiceStatusAdapter;
+import org.apache.hc.client5.http.classic.HttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import jakarta.ws.rs.client.Client;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,17 +23,19 @@ public class ActuatorBasedServiceStatusAdapterFactoryImpl implements ServiceStat
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ActuatorBasedServiceStatusAdapterFactoryImpl.class);
 
-    private final Client client;
+    private final HttpClient httpClient;
+    private final ResponseReader responseReader;
 
     @Autowired
-    public ActuatorBasedServiceStatusAdapterFactoryImpl(Client client) {
-        this.client = client;
+    public ActuatorBasedServiceStatusAdapterFactoryImpl(HttpClient httpClient, ResponseReader responseReader) {
+        this.httpClient = httpClient;
+        this.responseReader = responseReader;
     }
 
     @Override
     public ActuatorBasedServiceStatusAdapter create(String abbreviation, String url) {
         LOGGER.info("Initializing adapter for service {}", abbreviation);
-        return new ActuatorBasedServiceStatusAdapter(client, abbreviation, url);
+        return new ActuatorBasedServiceStatusAdapter(httpClient, responseReader, abbreviation, url);
     }
 
     @Override

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/status/impl/ActuatorBasedServiceStatusAdapter.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/status/impl/ActuatorBasedServiceStatusAdapter.java
@@ -1,12 +1,16 @@
 package hu.psprog.leaflet.lsas.core.status.impl;
 
+import hu.psprog.leaflet.bridge.client.handler.ResponseReader;
 import hu.psprog.leaflet.lsas.core.domain.ServiceStatus;
 import hu.psprog.leaflet.lsas.core.status.ServiceStatusAdapter;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.type.TypeReference;
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Type;
 
 /**
  * {@link ServiceStatusAdapter} implementation for services providing Spring Boot Actuator based status endpoints.
@@ -17,13 +21,23 @@ public class ActuatorBasedServiceStatusAdapter implements ServiceStatusAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ActuatorBasedServiceStatusAdapter.class);
 
-    private final Client client;
+    private static final TypeReference<ServiceStatus> SERVICE_STATUS_TYPE_REFERENCE = new TypeReference<>() {
+        @Override
+        public Type getType() {
+            return ServiceStatus.class;
+        }
+    };
+
+    private final HttpClient httpClient;
+    private final ResponseReader responseReader;
     private final String serviceAbbreviation;
     private final String statusURL;
     private final ServiceStatus defaultServiceStatus;
 
-    public ActuatorBasedServiceStatusAdapter(Client client, String serviceAbbreviation, String statusURL) {
-        this.client = client;
+    public ActuatorBasedServiceStatusAdapter(HttpClient httpClient, ResponseReader responseReader,
+                                             String serviceAbbreviation, String statusURL) {
+        this.httpClient = httpClient;
+        this.responseReader = responseReader;
         this.serviceAbbreviation = serviceAbbreviation;
         this.statusURL = statusURL;
         this.defaultServiceStatus = ServiceStatus.buildDownService(serviceAbbreviation);
@@ -40,20 +54,14 @@ public class ActuatorBasedServiceStatusAdapter implements ServiceStatusAdapter {
         LOGGER.info("Calling service {} to request status", serviceAbbreviation);
 
         ServiceStatus serviceStatus = defaultServiceStatus;
-        try (Response response = callService()) {
-            if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
-                serviceStatus = response.readEntity(ServiceStatus.class);
-            }
-        } catch (Exception e) {
-            LOGGER.error("Failed to call service {} - reason: {}", serviceAbbreviation, e.getMessage());
+        try {
+            ClassicHttpRequest request = new HttpGet(statusURL);
+            serviceStatus = httpClient.execute(request, response -> responseReader.read(response, SERVICE_STATUS_TYPE_REFERENCE));
+
+        } catch (Exception exception) {
+            LOGGER.error("Failed to call service {} - reason: {}", serviceAbbreviation, exception.getMessage(), exception);
         }
 
         return serviceStatus;
-    }
-
-    private Response callService() {
-        return client.target(statusURL)
-                .request()
-                .get();
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/utility/CPUUsageCalculator.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/utility/CPUUsageCalculator.java
@@ -2,8 +2,10 @@ package hu.psprog.leaflet.lsas.core.utility;
 
 import hu.psprog.leaflet.lsas.core.dockerapi.CPUStatsModel;
 import hu.psprog.leaflet.lsas.core.dockerapi.ContainerRuntimeStatsModel;
-import org.apache.commons.math3.util.Precision;
 import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 /**
  * Utility class to calculate CPU usage of Docker containers.
@@ -19,7 +21,7 @@ public class CPUUsageCalculator {
 
     /**
      * Calculates CPU usage as percentage.
-     *
+     * <p>
      * Calculation is based on the algorithm described in Docker Engine's documentation:
      *  1) Delta of the current and previous total CPU usage of the container process is calculated.
      *  2) Delta of the current and previous total CPU usage of the system is calculated.
@@ -59,6 +61,8 @@ public class CPUUsageCalculator {
         int numberOfCPUs = currentCPUStats.onlineCPUs();
         double rawCPULoad = (processCPUUsageDelta / systemCPUUsageDelta) * numberOfCPUs * PERCENTAGE_MULTIPLIER;
 
-        return Precision.round(rawCPULoad, PRECISION_SCALE);
+        return (new BigDecimal(Double.toString(rawCPULoad))
+                .setScale(PRECISION_SCALE, RoundingMode.HALF_UP))
+                .doubleValue();
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/utility/MemoryUsageCalculator.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/utility/MemoryUsageCalculator.java
@@ -2,9 +2,10 @@ package hu.psprog.leaflet.lsas.core.utility;
 
 import hu.psprog.leaflet.lsas.core.dockerapi.ContainerRuntimeStatsModel;
 import hu.psprog.leaflet.lsas.core.dockerapi.MemoryStatsModel;
-import org.apache.commons.math3.util.Precision;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Optional;
 
 /**
@@ -23,7 +24,7 @@ public class MemoryUsageCalculator {
 
     /**
      * Calculates used memory in MB.
-     *
+     * <p>
      * Calculation is based on the algorithm described in Docker Engine's documentation:
      *  1) Amount of cached memory usage is subtracted from the currently used total memory of the container.
      *  2) Calculated value is divided by MEGABYTES_DIVIDER (byte -> MB) and returned.
@@ -41,7 +42,7 @@ public class MemoryUsageCalculator {
 
     /**
      * Calculates used memory as percentage of the total available system memory.
-     *
+     * <p>
      * Calculation is based on the algorithm described in Docker Engine's documentation:
      *  1) Amount of cached memory usage is subtracted from the currently used total memory of the container.
      *  2) Calculated value is divided by the total available memory ("limit").
@@ -55,7 +56,9 @@ public class MemoryUsageCalculator {
         return Optional.ofNullable(containerRuntimeStatsModel.memoryStats())
                 .filter(memory -> memory.limit() > 0)
                 .map(memory -> calculateMemoryUsage(memory) / ((double) memory.limit()) * PERCENTAGE_MULTIPLIER)
-                .map(memoryUsagePercentage -> Precision.round(memoryUsagePercentage, PRECISION_SCALE))
+                .map(memoryUsagePercentage -> (new BigDecimal(Double.toString(memoryUsagePercentage))
+                        .setScale(PRECISION_SCALE, RoundingMode.HALF_UP))
+                        .doubleValue())
                 .orElse(DOUBLE_ZERO);
     }
 

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactoryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/client/factory/DockerEngineWebClientFactoryTest.java
@@ -1,6 +1,5 @@
 package hu.psprog.leaflet.lsas.core.client.factory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
 import io.netty.channel.unix.DomainSocketAddress;
 import org.junit.jupiter.api.Test;
@@ -13,11 +12,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.ClientCodecConfigurer;
-import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.JacksonJsonDecoder;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientConfig;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.lang.reflect.Field;
 import java.util.function.Consumer;
@@ -46,7 +46,7 @@ class DockerEngineWebClientFactoryTest {
     private ServiceRegistrations serviceRegistrations;
 
     @Mock
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     @Mock
     private WebClient.Builder webClientBuilder;
@@ -130,7 +130,7 @@ class DockerEngineWebClientFactoryTest {
 
         Consumer<ClientCodecConfigurer> configurerValue = codecCaptor.getValue();
         configurerValue.accept(clientCodecConfigurer);
-        verify(clientDefaultCodecs).jackson2JsonDecoder(any(Jackson2JsonDecoder.class));
+        verify(clientDefaultCodecs).jacksonJsonDecoder(any(JacksonJsonDecoder.class));
     }
 
     private HttpClient extractClient(ClientHttpConnector clientHttpConnector) throws IllegalAccessException {
@@ -159,6 +159,6 @@ class DockerEngineWebClientFactoryTest {
 
         given(serviceRegistrations.getDockerIntegration()).willReturn(dockerIntegration);
 
-        dockerEngineWebClientFactory = new DockerEngineWebClientFactory(serviceRegistrations, objectMapper);
+        dockerEngineWebClientFactory = new DockerEngineWebClientFactory(serviceRegistrations, jsonMapper);
     }
 }

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImplTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImplTest.java
@@ -1,6 +1,5 @@
 package hu.psprog.leaflet.lsas.core.client.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -15,9 +14,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.JacksonJsonDecoder;
 import org.springframework.util.MimeType;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,8 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class DockerRegistryClientImplTest {
 
     private static final ServiceRegistrations SERVICE_REGISTRATIONS = prepareConfig();
-    private static final Jackson2JsonDecoder DOCKER_MANIFEST_DECODER =
-            new Jackson2JsonDecoder(new ObjectMapper(), new MimeType("application", "vnd.docker.distribution.manifest.v1+prettyjws"));
+    private static final JacksonJsonDecoder DOCKER_MANIFEST_DECODER =
+            new JacksonJsonDecoder(new JsonMapper(), new MimeType("application", "vnd.docker.distribution.manifest.v1+prettyjws"));
 
     private static final String REGISTRY_ID_1 = "registry-1";
     private static final String REGISTRY_ID_2 = "registry-2";
@@ -64,7 +64,7 @@ class DockerRegistryClientImplTest {
 
     private static WireMockServer wireMockServerRegistry1;
     private static WireMockServer wireMockServerRegistry2;
-    private static DockerRegistryClient dockerRegistryClient =
+    private static final DockerRegistryClient dockerRegistryClient =
             new DockerRegistryClientImpl(SERVICE_REGISTRATIONS, DOCKER_MANIFEST_DECODER);
 
     @BeforeAll

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/service/factory/impl/ActuatorBasedServiceStatusAdapterFactoryImplTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/service/factory/impl/ActuatorBasedServiceStatusAdapterFactoryImplTest.java
@@ -1,6 +1,8 @@
 package hu.psprog.leaflet.lsas.core.service.factory.impl;
 
+import hu.psprog.leaflet.bridge.client.handler.ResponseReader;
 import hu.psprog.leaflet.lsas.core.status.impl.ActuatorBasedServiceStatusAdapter;
+import org.apache.hc.client5.http.classic.HttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.ReflectionUtils;
 
-import jakarta.ws.rs.client.Client;
 import java.lang.reflect.Field;
 import java.util.Comparator;
 import java.util.List;
@@ -39,23 +40,29 @@ class ActuatorBasedServiceStatusAdapterFactoryImplTest {
             SVC_3, URL_3);
 
     @Mock
-    private Client client;
+    private HttpClient httpClient;
+
+    @Mock
+    private ResponseReader responseReader;
 
     @InjectMocks
     private ActuatorBasedServiceStatusAdapterFactoryImpl actuatorBasedServiceStatusAdapterFactory;
 
     private Field clientField;
+    private Field responseReaderField;
     private Field abbreviationField;
     private Field statusUrlField;
 
     @BeforeEach
     void setup() {
 
-        clientField = ReflectionUtils.findField(ActuatorBasedServiceStatusAdapter.class, "client");
+        clientField = ReflectionUtils.findField(ActuatorBasedServiceStatusAdapter.class, "httpClient");
+        responseReaderField = ReflectionUtils.findField(ActuatorBasedServiceStatusAdapter.class, "responseReader");
         abbreviationField = ReflectionUtils.findField(ActuatorBasedServiceStatusAdapter.class, "serviceAbbreviation");
         statusUrlField = ReflectionUtils.findField(ActuatorBasedServiceStatusAdapter.class, "statusURL");
 
         clientField.setAccessible(true);
+        responseReaderField.setAccessible(true);
         abbreviationField.setAccessible(true);
         statusUrlField.setAccessible(true);
     }
@@ -75,7 +82,8 @@ class ActuatorBasedServiceStatusAdapterFactoryImplTest {
     }
 
     private void assertAdapter(ActuatorBasedServiceStatusAdapter adapter, String abbreviation, String url) throws IllegalAccessException {
-        assertThat(clientField.get(adapter), equalTo(client));
+        assertThat(clientField.get(adapter), equalTo(httpClient));
+        assertThat(responseReaderField.get(adapter), equalTo(responseReader));
         assertThat(abbreviationField.get(adapter), equalTo(abbreviation));
         assertThat(statusUrlField.get(adapter), equalTo(url));
     }

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/status/impl/ActuatorBasedServiceStatusAdapterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/status/impl/ActuatorBasedServiceStatusAdapterTest.java
@@ -1,24 +1,32 @@
 package hu.psprog.leaflet.lsas.core.status.impl;
 
+import hu.psprog.leaflet.bridge.client.handler.ResponseReader;
 import hu.psprog.leaflet.lsas.core.domain.BuildInfo;
 import hu.psprog.leaflet.lsas.core.domain.ServiceInfo;
 import hu.psprog.leaflet.lsas.core.domain.ServiceStatus;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.core.type.TypeReference;
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doAnswer;
 
 /**
  * Unit tests for {@link ActuatorBasedServiceStatusAdapter}.
@@ -36,48 +44,57 @@ class ActuatorBasedServiceStatusAdapterTest {
     private static final ServiceStatus SERVICE_STATUS = new ServiceStatus(SERVICE_INFO, BUILD_INFO);
 
     @Mock
-    private Client client;
+    private HttpClient httpClient;
 
     @Mock
-    private WebTarget webTarget;
+    private ClassicHttpResponse response;
 
     @Mock
-    private Invocation.Builder builder;
+    private ResponseReader responseReader;
 
-    @Mock
-    private Response response;
+    @Captor
+    private ArgumentCaptor<HttpClientResponseHandler<ServiceStatus>> responseHandlerCaptor;
+
+    @Captor
+    private ArgumentCaptor<TypeReference<ServiceStatus>> typeReferenceCaptor;
+
+    @Captor
+    private ArgumentCaptor<HttpGet> requestCaptor;
 
     private ActuatorBasedServiceStatusAdapter actuatorBasedServiceStatusAdapter;
 
     @BeforeEach
     void setup() {
-        actuatorBasedServiceStatusAdapter = new ActuatorBasedServiceStatusAdapter(client, SERVICE_ABBREVIATION, STATUS_URL);
+        actuatorBasedServiceStatusAdapter = new ActuatorBasedServiceStatusAdapter(httpClient, responseReader, SERVICE_ABBREVIATION, STATUS_URL);
     }
 
     @Test
-    void shouldGetStatusWithSuccess() {
+    void shouldGetStatusWithSuccess() throws IOException, HttpException, URISyntaxException {
 
         // given
-        given(client.target(STATUS_URL)).willReturn(webTarget);
-        given(webTarget.request()).willReturn(builder);
-        given(builder.get()).willReturn(response);
-        given(response.getStatusInfo()).willReturn(Response.Status.OK);
-        given(response.readEntity(ServiceStatus.class)).willReturn(SERVICE_STATUS);
+        given(httpClient.execute(requestCaptor.capture(), responseHandlerCaptor.capture())).willReturn(SERVICE_STATUS);
+        given(responseReader.read(eq(response), typeReferenceCaptor.capture())).willReturn(SERVICE_STATUS);
 
         // when
         ServiceStatus result = actuatorBasedServiceStatusAdapter.getStatus();
 
         // then
+        responseHandlerCaptor.getValue().handleResponse(response);
+
         assertThat(result, equalTo(SERVICE_STATUS));
+        assertThat(typeReferenceCaptor.getValue().getType(), equalTo(ServiceStatus.class));
+
+        HttpGet request = requestCaptor.getValue();
+        assertThat(request.getMethod(), equalTo("GET"));
+        assertThat(request.getPath(), equalTo("/api"));
+        assertThat(request.getUri().toString(), equalTo(STATUS_URL));
     }
 
     @Test
-    void shouldGetStatusReturnWithDownServiceForException() {
+    void shouldGetStatusReturnWithDownServiceForException() throws IOException {
 
         // given
-        given(client.target(STATUS_URL)).willReturn(webTarget);
-        given(webTarget.request()).willReturn(builder);
-        doThrow(RuntimeException.class).when(builder).get();
+        given(httpClient.execute(requestCaptor.capture(), responseHandlerCaptor.capture())).willThrow(IOException.class);
 
         // when
         ServiceStatus result = actuatorBasedServiceStatusAdapter.getStatus();
@@ -87,13 +104,15 @@ class ActuatorBasedServiceStatusAdapterTest {
     }
 
     @Test
-    void shouldGetStatusReturnWithDownServiceForNonSuccessfulResponse() {
+    void shouldGetStatusReturnWithDownServiceForNonSuccessfulResponse() throws IOException {
 
         // given
-        given(client.target(STATUS_URL)).willReturn(webTarget);
-        given(webTarget.request()).willReturn(builder);
-        given(builder.get()).willReturn(response);
-        given(response.getStatusInfo()).willReturn(Response.Status.INTERNAL_SERVER_ERROR);
+        given(responseReader.read(eq(response), typeReferenceCaptor.capture())).willThrow(RuntimeException.class);
+        doAnswer(invocation -> {
+            var handler = invocation.getArgument(1, HttpClientResponseHandler.class);
+            handler.handleResponse(response);
+            return null;
+        }).when(httpClient).execute(requestCaptor.capture(), responseHandlerCaptor.capture());
 
         // when
         ServiceStatus result = actuatorBasedServiceStatusAdapter.getStatus();

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>lsas</artifactId>
     <packaging>pom</packaging>
-    <version>2.8.1-dev</version>
+    <version>2.9.0-dev</version>
 
     <modules>
         <module>web</module>
@@ -16,7 +16,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>5.0-r2505.1</version>
+        <version>6.0-r2604.3</version>
     </parent>
 
     <properties>
@@ -73,10 +73,6 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
@@ -87,11 +83,30 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                    <proc>full</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${argLine.surefire}</argLine>
+                    <argLine>${argLine.surefire} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lsas</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.8.1-dev</version>
+        <version>2.9.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -25,12 +25,8 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-resource-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-jose</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
         </dependency>
     </dependencies>
 
@@ -46,7 +42,6 @@
                         <argument>--spring.profiles.active=${spring.profiles.active}</argument>
                         <argument>--spring.config.location=${spring.config.location}</argument>
                     </arguments>
-                    <executable>true</executable>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
 - Aligned Jackson imports and configuration
 - Switched to stack base BOM v6.0-r2604.3
 - Bumped application version to 2.9.0-dev
 - POM fixes (annotation processing and Mockito warnings)
 - Added OAuth application descriptor and import step in pipeline
 - Added deploy markers to CircleCI config