### PR TITLE
LFLT-660 Align reading the existing Docker tags of a repository in LSAS with the new Registry version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lsas</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.9.0-dev</version>
+        <version>2.9.1-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/client/DockerRegistryClient.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/client/DockerRegistryClient.java
@@ -1,5 +1,6 @@
 package hu.psprog.leaflet.lsas.core.client;
 
+import hu.psprog.leaflet.lsas.core.dockerapi.DockerBlobManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerRepositories;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTagManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTags;
@@ -39,6 +40,16 @@ public interface DockerRegistryClient {
      * @return image manifest as {@link DockerTagManifest} object wrapped in {@link Mono}
      */
     Mono<DockerTagManifest> getTagManifest(String registryID, String repositoryID, String tag);
+
+    /**
+     * Retrieves manifest details of the given blob.
+     *
+     * @param registryID ID of the registry the repository is located in
+     * @param repositoryID ID of the repository to retrieve the manifest of
+     * @param digest digest value (sha256:...) of an existing Docker blob
+     * @return blob manifest as {@link DockerBlobManifest} object wrapped in {@link Mono}
+     */
+    Mono<DockerBlobManifest> getBlobManifest(String registryID, String repositoryID, String digest);
 
     /**
      * Retrieves manifest digest of the given tag of an image.

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImpl.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImpl.java
@@ -2,6 +2,7 @@ package hu.psprog.leaflet.lsas.core.client.impl;
 
 import hu.psprog.leaflet.lsas.core.client.DockerRegistryClient;
 import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
+import hu.psprog.leaflet.lsas.core.dockerapi.DockerBlobManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerRepositories;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTagManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTags;
@@ -62,6 +63,17 @@ public class DockerRegistryClientImpl implements DockerRegistryClient {
                 .uri(String.format(DockerRegistryPath.TAG_MANIFEST.getUri(), repositoryID, tag))
                 .retrieve()
                 .bodyToMono(DockerTagManifest.class);
+    }
+
+    @Override
+    public Mono<DockerBlobManifest> getBlobManifest(String registryID, String repositoryID, String digest) {
+
+        return getWebClient(registryID)
+                .method(HttpMethod.GET)
+                .uri(String.format(DockerRegistryPath.BLOB_MANIFEST.getUri(), repositoryID, digest))
+                .header("Accept", "application/octet-stream")
+                .retrieve()
+                .bodyToMono(DockerBlobManifest.class);
     }
 
     @Override

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/config/ServiceConfiguration.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/config/ServiceConfiguration.java
@@ -57,7 +57,11 @@ public class ServiceConfiguration {
 
     @Bean
     public JacksonJsonDecoder dockerManifestDecoder(JsonMapper jsonMapper) {
-        return new JacksonJsonDecoder(jsonMapper, new MimeType("application", "vnd.docker.distribution.manifest.v1+prettyjws"));
+
+        return new JacksonJsonDecoder(jsonMapper,
+                MimeType.valueOf("application/vnd.docker.distribution.manifest.v1+prettyjws"),
+                // for reading blob manifests
+                MimeType.valueOf("application/octet-stream"));
     }
 
     static class DummyRequestAdapter implements RequestAdapter {

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/DockerBlobManifest.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/DockerBlobManifest.java
@@ -1,0 +1,16 @@
+package hu.psprog.leaflet.lsas.core.dockerapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Model class representing the response of a Docker blob manifest request.
+ *
+ * @author Peter Smith
+ */
+@Builder
+@Jacksonized
+public record DockerBlobManifest(
+    @JsonProperty("created") String created
+) { }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/DockerTagManifest.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/dockerapi/DockerTagManifest.java
@@ -1,30 +1,23 @@
 package hu.psprog.leaflet.lsas.core.dockerapi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.List;
+import lombok.Builder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * Model class representing the response of a Docker tag manifest request.
  *
  * @author Peter Smith
  */
+@Builder
+@Jacksonized
 public record DockerTagManifest(
-        @JsonProperty("tag") String tag,
-        @JsonProperty("history") List<DockerTagHistory> history
+        @JsonProperty("config") DockerTagManifestConfig config
 ) {
 
-    @JsonCreator
-    public DockerTagManifest {
-    }
-
-    public record DockerTagHistory(
-            @JsonProperty("v1Compatibility") String v1Compatibility
-    ) {
-
-        @JsonCreator
-        public DockerTagHistory {
-        }
-    }
+    @Builder
+    @Jacksonized
+    public record DockerTagManifestConfig(
+            @JsonProperty("digest") String digest
+    ) { }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/domain/DockerRegistryPath.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/domain/DockerRegistryPath.java
@@ -1,23 +1,22 @@
 package hu.psprog.leaflet.lsas.core.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 /**
  * Enum defining available Docker Registry API paths.
  *
  * @author Peter Smith
  */
+@Getter
+@RequiredArgsConstructor
 public enum DockerRegistryPath {
 
     REPOSITORIES("/v2/_catalog"),
     TAGS("/v2/%s/tags/list"),
-    TAG_MANIFEST("/v2/%s/manifests/%s");
+    TAG_MANIFEST("/v2/%s/manifests/%s"),
+    BLOB_MANIFEST("/v2/%s/blobs/%s");
 
     private final String uri;
 
-    DockerRegistryPath(String uri) {
-        this.uri = uri;
-    }
-
-    public String getUri() {
-        return uri;
-    }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lsas/core/service/impl/DockerRegistryServiceImpl.java
+++ b/core/src/main/java/hu/psprog/leaflet/lsas/core/service/impl/DockerRegistryServiceImpl.java
@@ -1,10 +1,9 @@
 package hu.psprog.leaflet.lsas.core.service.impl;
 
-import com.jayway.jsonpath.JsonPath;
 import hu.psprog.leaflet.lsas.core.client.DockerRegistryClient;
 import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
+import hu.psprog.leaflet.lsas.core.dockerapi.DockerBlobManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerRepositories;
-import hu.psprog.leaflet.lsas.core.dockerapi.DockerTagManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTags;
 import hu.psprog.leaflet.lsas.core.domain.DockerRegistryContent;
 import hu.psprog.leaflet.lsas.core.domain.DockerRepository;
@@ -19,7 +18,6 @@ import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -59,8 +57,9 @@ public class DockerRegistryServiceImpl implements DockerRegistryService {
                 .filter(dockerTags -> Objects.nonNull(dockerTags.tags()))
                 .map(DockerTags::tags)
                 .flatMapMany(Flux::fromIterable)
-                .flatMap(tag -> dockerRegistryClient.getTagManifest(registryID, repositoryID, tag))
-                .map(this::mapToDockerTag)
+                .flatMap(tag -> dockerRegistryClient.getTagManifest(registryID, repositoryID, tag)
+                        .flatMap(tagManifest -> dockerRegistryClient.getBlobManifest(registryID, repositoryID, tagManifest.config().digest()))
+                        .map(blobManifest -> mapToDockerTag(tag, blobManifest)))
                 .sort(Comparator
                         .comparing(DockerTag::created)
                         .thenComparing(DockerTag::name)
@@ -85,16 +84,7 @@ public class DockerRegistryServiceImpl implements DockerRegistryService {
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getHost()));
     }
 
-    private DockerTag mapToDockerTag(DockerTagManifest dockerTagManifest) {
-
-        ZonedDateTime created = dockerTagManifest.history().stream()
-                .map(DockerTagManifest.DockerTagHistory::v1Compatibility)
-                .map(metaString -> JsonPath.read(metaString, "$.created"))
-                .map(String::valueOf)
-                .map(ZonedDateTime::parse)
-                .max(Comparator.comparing(Function.identity()))
-                .orElse(null);
-
-        return new DockerTag(dockerTagManifest.tag(), created);
+    private DockerTag mapToDockerTag(String tag, DockerBlobManifest blobManifest) {
+        return new DockerTag(tag, ZonedDateTime.parse(blobManifest.created()));
     }
 }

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImplTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/client/impl/DockerRegistryClientImplTest.java
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import hu.psprog.leaflet.lsas.core.client.DockerRegistryClient;
 import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
+import hu.psprog.leaflet.lsas.core.dockerapi.DockerBlobManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerRepositories;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTagManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTags;
@@ -20,8 +21,6 @@ import reactor.core.publisher.Mono;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
@@ -44,8 +43,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class DockerRegistryClientImplTest {
 
     private static final ServiceRegistrations SERVICE_REGISTRATIONS = prepareConfig();
-    private static final JacksonJsonDecoder DOCKER_MANIFEST_DECODER =
-            new JacksonJsonDecoder(new JsonMapper(), new MimeType("application", "vnd.docker.distribution.manifest.v1+prettyjws"));
+    private static final JacksonJsonDecoder DOCKER_MANIFEST_DECODER = new JacksonJsonDecoder(new JsonMapper(),
+            MimeType.valueOf("application/vnd.docker.distribution.manifest.v1+prettyjws"),
+            MimeType.valueOf("application/octet-stream"));
 
     private static final String REGISTRY_ID_1 = "registry-1";
     private static final String REGISTRY_ID_2 = "registry-2";
@@ -58,9 +58,9 @@ class DockerRegistryClientImplTest {
             .name(REPOSITORY_ID)
             .tags(Arrays.asList("1.0", "2.0", "latest"))
             .build();
-    private static final DockerTagManifest.DockerTagHistory DOCKER_TAG_HISTORY = new DockerTagManifest.DockerTagHistory("tag-history");
-    private static final DockerTagManifest DOCKER_TAG_MANIFEST = new DockerTagManifest(TAG, Collections.singletonList(DOCKER_TAG_HISTORY));
     private static final String TAG_DIGEST = "tag-digest";
+    private static final DockerTagManifest DOCKER_TAG_MANIFEST = new DockerTagManifest(new DockerTagManifest.DockerTagManifestConfig(TAG_DIGEST));
+    private static final DockerBlobManifest DOCKER_BLOB_MANIFEST = new DockerBlobManifest("2026-05-13T20:25:31Z");
 
     private static WireMockServer wireMockServerRegistry1;
     private static WireMockServer wireMockServerRegistry2;
@@ -107,7 +107,7 @@ class DockerRegistryClientImplTest {
 
         // when
         assertThrows(IllegalArgumentException.class,
-                () -> dockerRegistryClient.getRepositories("non-existing-registry"));
+                () -> dockerRegistryClient.getRepositories("non-existing-registry").block());
 
         // then
         // exception expected
@@ -144,18 +144,20 @@ class DockerRegistryClientImplTest {
     }
 
     @Test
-    public void shouldGetTagManifestThrowExceptionWhenResponseBodyIsMalformed() {
+    public void shouldGetBlobManifest() {
 
         // given
-        wireMockServerRegistry2.givenThat(get(urlEqualTo("/v2/repository-1/manifests/latest"))
-                .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("history", "value"))));
+        wireMockServerRegistry2.givenThat(get(urlEqualTo("/v2/repository-1/blobs/tag-digest"))
+                .withHeader("Accept", WireMock.equalTo("application/octet-stream"))
+                .willReturn(ResponseDefinitionBuilder.okForJson(DOCKER_BLOB_MANIFEST)
+                        .withHeader("Content-Type", "application/octet-stream")));
 
         // when
-        assertThrows(RuntimeException.class,
-                () -> dockerRegistryClient.getTagManifest(REGISTRY_ID_2, REPOSITORY_ID, TAG).block());
+        Mono<DockerBlobManifest> result = dockerRegistryClient.getBlobManifest(REGISTRY_ID_2, REPOSITORY_ID, TAG_DIGEST);
 
         // then
-        // exception expected
+        assertThat(result.block(), equalTo(DOCKER_BLOB_MANIFEST));
+        verifyAuthorization(wireMockServerRegistry2);
     }
 
     @Test

--- a/core/src/test/java/hu/psprog/leaflet/lsas/core/service/impl/DockerRegistryServiceImplTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lsas/core/service/impl/DockerRegistryServiceImplTest.java
@@ -2,6 +2,7 @@ package hu.psprog.leaflet.lsas.core.service.impl;
 
 import hu.psprog.leaflet.lsas.core.client.DockerRegistryClient;
 import hu.psprog.leaflet.lsas.core.config.ServiceRegistrations;
+import hu.psprog.leaflet.lsas.core.dockerapi.DockerBlobManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerRepositories;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTagManifest;
 import hu.psprog.leaflet.lsas.core.dockerapi.DockerTags;
@@ -19,7 +20,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -104,10 +104,16 @@ class DockerRegistryServiceImplTest {
         String registryID = "leaflet";
         String repositoryID = "cbfs";
         Map<String, DockerTagManifest> tags = Map.of(
-                "latest", prepareManifest("latest", 0),
-                "1.0", prepareManifest("1.0", -10),
-                "2.0", prepareManifest("2.0", -5),
-                "3.0", prepareManifest("3.0", 0)
+                "latest", prepareTagManifest("sha256:latest"),
+                "1.0", prepareTagManifest("sha256:1.0"),
+                "2.0", prepareTagManifest("sha256:2.0"),
+                "3.0", prepareTagManifest("sha256:3.0")
+        );
+        Map<String, DockerBlobManifest> blobs = Map.of(
+                "sha256:latest", prepareBlobManifest(0),
+                "sha256:1.0", prepareBlobManifest(-10),
+                "sha256:2.0", prepareBlobManifest(-5),
+                "sha256:3.0", prepareBlobManifest(0)
         );
         DockerTags dockerTags = DockerTags.builder()
                 .name(repositoryID)
@@ -117,6 +123,9 @@ class DockerRegistryServiceImplTest {
         given(dockerRegistryClient.getRepositoryTags(registryID,  repositoryID)).willReturn(Mono.just(dockerTags));
         tags.forEach((tag, manifest) ->
                 given(dockerRegistryClient.getTagManifest(registryID, repositoryID, tag))
+                        .willReturn(Mono.just(manifest)));
+        blobs.forEach((digest, manifest) ->
+                given(dockerRegistryClient.getBlobManifest(registryID, repositoryID, digest))
                         .willReturn(Mono.just(manifest)));
 
         // when
@@ -148,15 +157,16 @@ class DockerRegistryServiceImplTest {
         verify(dockerRegistryClient).deleteTagByDigest(registryID, repositoryID, tagDigest);
     }
 
-    private DockerTagManifest prepareManifest(String tag, int dayOffset) {
+    private DockerTagManifest prepareTagManifest(String digest) {
+        return new DockerTagManifest(new DockerTagManifest.DockerTagManifestConfig(digest));
+    }
+
+    private DockerBlobManifest prepareBlobManifest(int dayOffset) {
 
         ZonedDateTime baseTime = ZonedDateTime
                 .of(2021, 1, 5, 22, 0, 0, 0, ZoneId.of("UTC"))
                 .plusDays(dayOffset);
 
-        String v1Compatibility = String.format("{\"created\":\"%s\"}", baseTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
-        DockerTagManifest.DockerTagHistory tagHistory = new DockerTagManifest.DockerTagHistory(v1Compatibility);
-
-        return new DockerTagManifest(tag, Collections.singletonList(tagHistory));
+        return new DockerBlobManifest(baseTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>lsas</artifactId>
     <packaging>pom</packaging>
-    <version>2.9.0-dev</version>
+    <version>2.9.1-dev</version>
 
     <modules>
         <module>web</module>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lsas</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.9.0-dev</version>
+        <version>2.9.1-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Fixed retrieving Docker tags from Registry
 - Bumped application version to 2.9.1-dev